### PR TITLE
UPDATE: Add new Virtualization support in a separated composed format

### DIFF
--- a/Docker/ClientServer/supervisord.conf
+++ b/Docker/ClientServer/supervisord.conf
@@ -1,0 +1,14 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
+
+[program:mammoth]
+command=echo "__IMPLEMENT__"
+stdout_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=false
+startretries=2

--- a/Docker/ControlPlane/supervisord.conf
+++ b/Docker/ControlPlane/supervisord.conf
@@ -1,0 +1,14 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+pidfile=/run/supervisord.pid
+
+[program:mammoth]
+command=/srv/mammoth-server/WorldQLServer -server
+stdout_logfile=/dev/stderr
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autorestart=false
+startretries=2

--- a/Docker/mammothClientServer.dockerfile
+++ b/Docker/mammothClientServer.dockerfile
@@ -1,0 +1,40 @@
+FROM openjdk:16.0.2-slim
+
+LABEL Maintainer="The WorldQL Team"
+LABEL Description="A plain client server image for Mammoth"
+
+# Set up WorldQL's base values
+ENV WQL_LEAF_SQUARE_SIZE=16
+ENV WQL_TREE_DEGREE=512
+ENV WQL_NUM_LEVELS=2
+ENV WQL_ROOTS_PER_TABLE=8
+
+# Set up the base Java values
+ENV JAVA_MEMORY_MIN="128M"
+ENV JAVA_MEMORY_MAX="512M"
+ENV JAVA_ARGS=""
+
+RUN apt update
+RUN apt install -y wget
+
+# Time to build/download the client server and install the Mamoth plugin from the release
+WORKDIR /srv/minecraft
+
+RUN wget -O spigot.jar "https://download.getbukkit.org/spigot/spigot-1.17.1.jar"
+
+# To actually run, we need a eula.txt and we need to download and install mammoth
+RUN echo "eula=true" > eula.txt
+RUN mkdir -pv ./plugins
+
+WORKDIR /srv/minecraft/plugins
+
+RUN wget https://github.com/WorldQL/mammoth/releases/download/v0.02-alpha/WorldQLClient-1.0-SNAPSHOT.jar
+
+WORKDIR /srv/minecraft
+
+# Bind our port as the last step before we get going
+EXPOSE 25565
+
+# Alright, now that we have everything done, the start command is to just run the server
+CMD java -Xms${JAVA_MEMORY_MIN} -Xmx${JAVA_MEMORY_MAX} ${JAVA_ARGS} -jar spigot.jar nogui
+# CMD sh

--- a/Docker/mammothControlPlane.dockerfile
+++ b/Docker/mammothControlPlane.dockerfile
@@ -1,0 +1,49 @@
+# TODO: Since this is a bare-minimum control plane, we might bee able to get away with bare Linux instead of Alpine to make this image TINY
+FROM alpine AS builder
+
+WORKDIR /tmp
+
+RUN apk add --update alpine-sdk postgresql-dev python3 libpq cmake
+RUN wget https://github.com/jtv/libpqxx/archive/refs/tags/6.4.7.zip && unzip 6.4.7.zip
+
+WORKDIR libpqxx-6.4.7
+
+RUN ./configure --disable-documentation
+RUN cmake src -Wno-dev
+RUN make
+
+#########################################
+FROM alpine
+
+LABEL Maintainer="The WorldQL Team"
+LABEL Description="The main control plane image for Mammoth"
+
+ENV WQL_LEAF_SQUARE_SIZE=16
+ENV WQL_TREE_DEGREE=512
+ENV WQL_NUM_LEVELS=2
+ENV WQL_ROOTS_PER_TABLE=8
+
+RUN apk update
+RUN apk upgrade
+RUN apk --no-cache add supervisor libzmq libpq libc6-compat
+
+COPY "./Docker/ControlPlane/supervisord.conf" /etc/supervisor/conf.d/supervisord.conf
+
+RUN mkdir -pv /srv/mammoth-server/
+RUN wget -O /srv/mammoth-server/WorldQLServer https://github.com/WorldQL/mammoth/releases/download/v0.01-alpha/WorldQLServer
+RUN chmod +x /srv/mammoth-server/WorldQLServer
+RUN chown -Rv nobody.nobody /srv/mammoth-server
+
+# We need to alter the run directory permissions for Supervisor
+RUN chown -R nobody.nobody /run
+
+# Lastly, copy in the libraries from the builder
+COPY --from=builder /tmp/libpqxx-6.4.7/libpqxx.so /usr/lib/libpqxx-6.4.so
+
+# Run as nobody since we don't want Mammoth to be a security hazard here
+USER nobody
+
+EXPOSE 5555
+EXPOSE 5556
+
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.8"
+
+services:
+  client-minecraft-server:
+    container_name: worldql-client
+    build:
+      dockerfile: Docker/mammothClientServer.dockerfile
+      context: .
+    environment:
+      WQL_POSTGRES_CONNECTION_STRING: "postgresql://docker:docker@postgres-db?port=5432&dbname=docker"
+    links:
+      - control-plane
+      - postgres-db
+    depends_on:
+      - control-plane
+      - postgres-db
+
+  control-plane:
+    container_name: worldql-mammoth
+    build:
+      dockerfile: Docker/mammothControlPlane.dockerfile
+      context: .
+    environment:
+      WQL_POSTGRES_CONNECTION_STRING: "postgresql://docker:docker@postgres-db?port=5432&dbname=docker"
+    links:
+      - postgres-db
+    depends_on:
+      - postgres-db
+
+  postgres-db:
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_USER: "docker"
+      POSTGRES_PASSWORD: "docker"
+      POSTGRES_DB: "docker"
+    restart: always
+
+# Uncomment this section to expose an adminer GUI to have a tool available for exploring the database
+  debug-adminer:
+    image: adminer:latest
+    restart: always
+    ports:
+      - "8080:8080"
+    environment:
+      ADMINER_DEFAULT_SERVER: "postgres-db"


### PR DESCRIPTION
 - Goal is to pave the way to full virtual stacks for ease of testing on real clusters
 - KNOWN ISSUE: Client server does not start properly and halts at init, this is being looked into
 - KNOWN ISSUE: There is no way to assign the port for the sever.  This is a known limitation that may not matter.